### PR TITLE
Make the API work.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,13 @@ license = "MIT"
 description = "Wrapper for ws281x library using bindgen to track upstream"
 
 [build]
-target = "armv7-unknown-linux-gnueabihf"
+target = "arm-unknown-linux-gnueabihf"
 
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.26"
-gcc = "0.3"
+bindgen = "0.37"
+cc = "1.0"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -18,3 +18,55 @@ Code is licensed under the MIT license, so as long as you are cool with
 that, feel free to open an issue, talk about proposed changes, then open
 a PR!  I would love a helping hand, just have to make sure things don't
 get too messy either.
+
+## Cross-compiling on Windows
+
+- Make sure Git is installed. This is used to clone the latest rpi-ws2811 lib.
+- Download and install libclang from [LLVM]; [32-bit for Windows][1]
+- Download and install [GCC][2] for the [Raspberry Pi][3].
+- Using rustup, install the 32-bit GCC Rust toolchain and set as default:
+    - `rustup default stable-i686-pc-windows-gnu`
+- Add the Raspberry Pi architecture target to the GCC toolchain:
+    - For all Raspberry Pi versions:
+    - `rustup target add arm-unknown-linux-gnueabihf`
+    - For an optimized Raspberry Pi 3 target (the ARMv7 architecture):
+    - `rustup target add armv7-unknown-linux-gnueabihf`
+- At the root of your Rust project, create a new directory and name it `.cargo`.
+  Inside that directory, create a file and paste the contents:
+    - ```
+      [build]
+      target = "arm-unknown-linux-gnueabihf"
+
+      [target.arm-unknown-linux-gnueabihf]
+      linker = "C:/SysGCC/raspberry/bin/arm-linux-gnueabihf-gcc.exe"
+      ```
+    - This informs Rust/Cargo to always use the arm-unknown-linux-gnueabihf target
+      (so that --target doesn't always have to be passed to cargo) and so that the
+      GCC linker for the given architecture is used.
+    - Be sure to change the linker path or the target architecture if you installed
+      the GCC ARM toolset in a different directory or are using the ARMv7 target
+      instead.
+- It is suggested to create a build script so that the necessary environment variables
+  can be set. This library needs to know where to find the GCC toolset in order to
+  cross compile the rpi-ws2811 C library for the Raspberry Pi.
+
+An example build script might look like this (using Git for Windows Bash):
+
+```
+#!/usr/bin/env bash
+
+# inform rpi-ws2811-rust where the GCC sysroot is
+export RPI_WS281X_SYSROOT=C:/SysGCC/raspberry/arm-linux-gnueabihf/sysroot
+# point to the GCC ARM compiler/linker.
+export CC_arm_unknown_linux_gnueabihf=C:/SysGCC/raspberry/bin/arm-linux-gnueabihf-gcc.exe
+# point to the GCC ARM archiver
+export AR_arm_unknown_linux_gnueabihf=C:/SysGCC/raspberry/bin/arm-linux-gnueabihf-ar.exe
+
+# run the build command
+cargo build $@
+```
+
+[LLVM]: http://releases.llvm.org/download.html
+[1]: http://releases.llvm.org/6.0.1/LLVM-6.0.1-win32.exe
+[2]: http://gnutoolchains.com/raspberry/
+[3]: http://sysprogs.com/files/gnutoolchains/raspberry/raspberry-gcc6.3.0-r3.exe

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate bindgen;
-extern crate gcc;
+extern crate cc;
 
 use std::env;
 use std::path::{PathBuf};
@@ -19,28 +19,43 @@ fn main() {
 		.output()
 		.expect("Failed to execute hostname command.");
 
-    gcc::Build::new()
+    // build a static lib
+    cc::Build::new()
         .file("src/rpi_ws281x/mailbox.c")
         .file("src/rpi_ws281x/ws2811.c")
         .file("src/rpi_ws281x/pwm.c")
         .file("src/rpi_ws281x/pcm.c")
         .file("src/rpi_ws281x/dma.c")
         .file("src/rpi_ws281x/rpihw.c")
-        .shared_flag(true)
-        .compile("libws2811.so");
-        
+        .shared_flag(false)
+        .compile("libws2811.a");
 
-    // Tell cargo to tell rustc to link the system bzip2
-    // shared library.
-    //println!("cargo:rustc-link-lib=libws2811.so");
+    // link to the created static lib
+    println!("cargo:rustc-link-lib=static=ws2811");
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
-    let bindings = bindgen::Builder::default()
+    let target = env::var("TARGET").unwrap();
+    let mut builder = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
         .header("src/wrapper.h")
+        // generate an rust enum for the return type of ws2811_init (instead of the
+        // the default of creating module-level consts).
+        .rustified_enum("ws2811_return_t")
+        .clang_arg("-target")
+        .clang_arg(target);
+
+    // Specifying the -target above seems to be sufficient for clang, but
+    // just in case, allow for the user to override the toolset sysroot.
+    // Note: this should be the path to the GCC ARM sysroot, *not* the libclang
+    // sysroot!
+    if let Ok(sysroot) = env::var("RPI_WS281X_SYSROOT") {
+        builder = builder.clang_arg(format!("--sysroot={}", sysroot));
+    }
+
+    let bindings = builder
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,0 +1,5 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/channel/channel.rs
+++ b/src/channel/channel.rs
@@ -1,18 +1,32 @@
-use bindings::*;
-use std::ptr::null_mut;
+use std::mem;
 
-pub struct Channel<'a> {
+use bindings::ws2811_channel_t;
+
+#[derive(Debug)]
+/// A wrapper around the low-level ws2811_channel_t struct.
+///
+/// Use the channel::builder::Builder to initialize.
+pub struct Channel {
     c_struct: ws2811_channel_t,
-    gpio_pin: i32,
-    led_count: i32,
-    invert: i32,
-    brightness: u8,
-    strip_type: Strip,
-    leds:  &'a[u8],
 }
 
-impl Channel {
-    unsafe fn init(&mut self) {
-        self.leds = std::slice::from_raw_parts_mut(self.c_struct.leds, self.led_count*std::mem::size_of(u32));
+impl  Channel {
+    pub fn new(c_struct: ws2811_channel_t ) -> Self {
+        Channel {
+            c_struct
+        }
+    }
+    /// Create an empty (literally mem-zeroed) channel.
+    pub fn empty() -> Self {
+        unsafe {
+            let c: ws2811_channel_t = mem::zeroed();
+            Channel {
+                c_struct: c
+            }
+        }
+    }
+
+    pub fn inner(&self) -> ws2811_channel_t {
+        self.c_struct
     }
 }

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -1,0 +1,5 @@
+mod builder;
+mod channel;
+
+pub use self::channel::Channel;
+pub use self::builder::{Builder as ChannelBuilder};

--- a/src/controller/builder.rs
+++ b/src/controller/builder.rs
@@ -1,34 +1,91 @@
-use std::{mem,ptr};
-use channel::Channel;
+use std::mem;
 
-pub struct Builder(Controller);
+use bindings::ws2811_t;
+
+use channel::Channel;
+use controller::Controller;
+
+const MAX_NUM_CHANNELS: usize = 2;
+
+/// Builds a Controller
+///
+/// ```
+/// // Construct a single channel controller (note: the second
+/// // channel is created by default). Note that the Controller
+/// // is initialized by default and is cleaned up on drop
+/// let controller = controller::Builder::default()
+///     // default
+///     .freq(800_000)
+///     // default
+///     .dma(10)
+///     .channel(
+///         channel::Builder::default()
+///             .gpio_num(18)
+///             .led_count(10)
+///             .strip_type(Strip::WS2811_STRIP_RGB)
+///             .brightness(255)
+///             .build()
+///      )
+///     .build();
+///
+/// // set the 5th pixel to RGB white on the first channel
+/// controller.set(0, 4, 0x00ffffff);
+/// // render it to the strand
+/// controller.render();
+/// ```
+pub struct Builder {
+    /// the frequency of the LED clock
+    freq: u32,
+    /// a DMA (direct memory access) number not already in use by the pi.
+    /// 5 is in use by the file system on Pi 3, so 10 is a good default.
+    dma: i32,
+    channels: [Channel; 2],
+}
+
+impl Default for Builder {
+    /// Initializes some common defaults
+    fn default() -> Self {
+        Builder {
+            freq: 800000,
+            dma: 10,
+            channels: [Channel::empty(), Channel::empty()],
+        }
+    }
+}
 
 impl Builder {
-    fn new() -> Self {
+    /// Set the controller frequency (in Hz); defaults to 800KHz
+    pub fn freq(&mut self, frequency: u32) -> &mut Self {
+        self.freq = frequency;
+        self
+    }
+
+    /// set the DMA number; defaults to 10
+    pub fn dma(&mut self, dma: i32) -> &mut Self {
+        self.dma = dma;
+        self
+    }
+
+    /// set a Channel at the given index (0 or 1).
+    pub fn channel(&mut self, channel: Channel, idx: usize) -> &mut Self {
+        self.channels[idx] = channel;
+        self
+    }
+
+    /// Build the final controller object.
+    pub fn build(&self) -> Controller {
         unsafe {
-            let mut controller: Controller = mem::zeroed();
-            controller.c_struct.freq = 800000;
-            return Builder(controller);
-        }
-    }
-    fn freq(&mut self, frequency: u32 ) -> Self {
-        self.0.c_struct.freq = frequency;
-        return self;
-    }
-    fn dma(&mut self, dmanum: i32 ) -> Self {
-        self.0.c_struct.dmanum = dmanum;
-        return self;
-    }
-    fn channel(&mut self, channel: Channel, idx: u8) -> Self {
-        unsafe {
-            self.0.c_struct.channel[idx] = channel.c_struct
-        }
-        self.0.c_struct.channel[idx] = channel;
-        return self;
-    }
-    fn build(&mut self) -> Result<Controller, ()> {
-        unsafe {
-            return Ok(ptr::read(&self.0));
+            let mut c_struct: ws2811_t = mem::zeroed();
+            c_struct.freq = self.freq;
+            c_struct.dmanum = self.dma;
+            for i in 0..MAX_NUM_CHANNELS {
+                c_struct.channel[i] = self.channels[i].inner();
+            }
+            let mut controller = Controller::new(c_struct);
+            if let Err(e) = controller.init() {
+                panic!(format!("Error initializing controller: {}", e))
+            }
+            controller
         }
     }
 }

--- a/src/controller/controller.rs
+++ b/src/controller/controller.rs
@@ -1,23 +1,63 @@
-use bindings;
-use util::{ws2811_init, ws2811_fini};
-use util::errors::WS281xError;
+use std::slice;
 
+use bindings::ws2811_t;
+use util::{ws2811_init, ws2811_fini, ws2811_render};
+use util::errors::WS281xResult;
+
+#[derive(Debug)]
+/// A manager object that provides a safe interface to the low-level rpi-ws281x functions.
 pub struct Controller {
     c_struct: ws2811_t
 }
 
 impl Controller {
-    pub unsafe fn new(value: ws2811_t) -> Result<Controller,()> {
-        return Ok(Controller{ c_struct: value });
-    }
 
-    pub fn init(&self) -> Result<(), WS281xError>  {
+    pub fn new(c_struct: ws2811_t) -> Self {
+        Controller {
+            c_struct
+        }
+    }
+    /// Initializes the underlying ws2811_t struct based on the partially initialized data.
+    ///
+    /// See the controller::builder::Builder for what needs to be initialized before calling.
+    ///
+    /// Note: this structure automatically calls ws2811_fini on Drop to free any internal memory.
+    pub fn init(&mut self) -> Result<(), WS281xResult> {
         return ws2811_init(&mut self.c_struct);
     }
 
+    /// Set the LED at index `idx` to `pixel` on the given channel.
+    ///
+    /// Note: there are a maximum of two channels and most of the time
+    ///       channel `0` will be used.
+    pub fn set(&mut self, channel_idx: usize, idx: usize, pixel: u32) {
+        let channel = self.c_struct.channel[channel_idx];
+        unsafe {
+            let leds = slice::from_raw_parts_mut(channel.leds, channel.count as usize);
+            leds[idx] = pixel;
+        }
+    }
+
+    /// Get the LED pixel value at index `idx` on the given channel.
+    ///
+    /// Note: there are a maximum of two channels and most of the time
+    ///       channel `0` will be used.
+    pub fn get(&self, channel_idx: usize, idx: usize) -> u32 {
+        let channel = self.c_struct.channel[channel_idx];
+        unsafe {
+            let leds = slice::from_raw_parts(channel.leds, channel.count as usize);
+            leds[idx]
+        }
+    }
+
+    /// Send the LED data to the strand.
+    pub fn render(&mut self) {
+        ws2811_render(&mut self.c_struct as *mut ws2811_t).expect("Unable to render");
+    }
 }
 
 impl Drop for Controller {
+    /// Calls ws2811_fini on to free any internal memory from init().
     fn drop(&mut self) {
         ws2811_fini(&mut self.c_struct);
     }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1,4 +1,6 @@
 mod controller;
+mod builder;
 
 pub use self::controller::Controller;
+pub use self::builder::{Builder as ControllerBuilder};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,10 @@ pub mod bindings;
 
 pub mod util;
 pub use util::errors;
-pub use util::strip;
+pub use util::strip::Strip;
 
 pub mod controller;
-pub use controller::{Controller};
+pub use controller::{Controller, ControllerBuilder};
 
+pub mod channel;
+pub use channel::{Channel, ChannelBuilder};

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -1,0 +1,101 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+use std::fmt;
+use std::error::Error;
+
+use bindings::ws2811_return_t;
+
+#[derive(Debug)]
+pub enum WS281xResult {
+    WS281X_ERROR_GENERIC,
+    WS281X_ERROR_OUT_OF_MEMORY,
+    WS281X_ERROR_HW_NOT_SUPPORTED,
+    WS281X_ERROR_MEM_LOCK,
+    WS281X_ERROR_MMAP,
+    WS281X_ERROR_MAP_REGISTERS,
+    WS281X_ERROR_GPIO_INIT,
+    WS281X_ERROR_PWM_SETUP,
+    WS281X_ERROR_MAILBOX_DEVICE,
+    WS281X_ERROR_DMA,
+    WS281X_ERROR_ILLEGAL_GPIO,
+    WS281X_ERROR_PCM_SETUP,
+    WS281X_ERROR_SPI_SETUP,
+    WS281X_ERROR_SPI_TRANSFER,
+    WS2811_SUCCESS,
+}
+
+impl From<ws2811_return_t> for WS281xResult {
+    fn from(value: ws2811_return_t) -> WS281xResult {
+        match value {
+            ws2811_return_t::WS2811_ERROR_GENERIC => WS281xResult::WS281X_ERROR_GENERIC,
+            ws2811_return_t::WS2811_ERROR_OUT_OF_MEMORY => WS281xResult::WS281X_ERROR_OUT_OF_MEMORY,
+            ws2811_return_t::WS2811_ERROR_HW_NOT_SUPPORTED => WS281xResult::WS281X_ERROR_HW_NOT_SUPPORTED,
+            ws2811_return_t::WS2811_ERROR_MEM_LOCK => WS281xResult::WS281X_ERROR_MEM_LOCK,
+            ws2811_return_t::WS2811_ERROR_MMAP => WS281xResult::WS281X_ERROR_MMAP,
+            ws2811_return_t::WS2811_ERROR_MAP_REGISTERS => WS281xResult::WS281X_ERROR_MAP_REGISTERS,
+            ws2811_return_t::WS2811_ERROR_GPIO_INIT => WS281xResult::WS281X_ERROR_GPIO_INIT,
+            ws2811_return_t::WS2811_ERROR_PWM_SETUP => WS281xResult::WS281X_ERROR_PWM_SETUP,
+            ws2811_return_t::WS2811_ERROR_MAILBOX_DEVICE => WS281xResult::WS281X_ERROR_MAILBOX_DEVICE,
+            ws2811_return_t::WS2811_ERROR_DMA => WS281xResult::WS281X_ERROR_DMA,
+            ws2811_return_t::WS2811_ERROR_ILLEGAL_GPIO => WS281xResult::WS281X_ERROR_ILLEGAL_GPIO,
+            ws2811_return_t::WS2811_ERROR_PCM_SETUP => WS281xResult::WS281X_ERROR_PCM_SETUP,
+            ws2811_return_t::WS2811_ERROR_SPI_SETUP => WS281xResult::WS281X_ERROR_SPI_SETUP,
+            ws2811_return_t::WS2811_ERROR_SPI_TRANSFER => WS281xResult::WS281X_ERROR_SPI_TRANSFER,
+            ws2811_return_t::WS2811_SUCCESS => WS281xResult::WS2811_SUCCESS,
+        }
+    }
+}
+
+impl Into<ws2811_return_t> for WS281xResult {
+    fn into(self) -> ws2811_return_t {
+        match self {
+            WS281xResult::WS281X_ERROR_GENERIC => ws2811_return_t::WS2811_ERROR_GENERIC,
+            WS281xResult::WS281X_ERROR_OUT_OF_MEMORY => ws2811_return_t::WS2811_ERROR_OUT_OF_MEMORY,
+            WS281xResult::WS281X_ERROR_HW_NOT_SUPPORTED => ws2811_return_t::WS2811_ERROR_HW_NOT_SUPPORTED,
+            WS281xResult::WS281X_ERROR_MEM_LOCK => ws2811_return_t::WS2811_ERROR_MEM_LOCK,
+            WS281xResult::WS281X_ERROR_MMAP => ws2811_return_t::WS2811_ERROR_MMAP,
+            WS281xResult::WS281X_ERROR_MAP_REGISTERS => ws2811_return_t::WS2811_ERROR_MAP_REGISTERS,
+            WS281xResult::WS281X_ERROR_GPIO_INIT => ws2811_return_t::WS2811_ERROR_GPIO_INIT,
+            WS281xResult::WS281X_ERROR_PWM_SETUP => ws2811_return_t::WS2811_ERROR_PWM_SETUP,
+            WS281xResult::WS281X_ERROR_MAILBOX_DEVICE => ws2811_return_t::WS2811_ERROR_MAILBOX_DEVICE,
+            WS281xResult::WS281X_ERROR_DMA => ws2811_return_t::WS2811_ERROR_DMA,
+            WS281xResult::WS281X_ERROR_ILLEGAL_GPIO => ws2811_return_t::WS2811_ERROR_ILLEGAL_GPIO,
+            WS281xResult::WS281X_ERROR_PCM_SETUP => ws2811_return_t::WS2811_ERROR_PCM_SETUP,
+            WS281xResult::WS281X_ERROR_SPI_SETUP => ws2811_return_t::WS2811_ERROR_SPI_SETUP,
+            WS281xResult::WS281X_ERROR_SPI_TRANSFER => ws2811_return_t::WS2811_ERROR_SPI_TRANSFER,
+            WS281xResult::WS2811_SUCCESS => ws2811_return_t::WS2811_SUCCESS,
+        }
+    }
+}
+
+impl Error for WS281xResult {
+    fn description(&self) -> &str {
+        match self {
+            WS281xResult::WS281X_ERROR_GENERIC => "Something went wrong with the WS281x driver (WS2811_ERROR_GENERIC)",
+            WS281xResult::WS281X_ERROR_OUT_OF_MEMORY => "Out of memory (WS2811_ERROR_OUT_OF_MEMORY)",
+            WS281xResult::WS281X_ERROR_HW_NOT_SUPPORTED => "Hardware not supported (WS2811_ERROR_HW_NOT_SUPPORTED",
+            WS281xResult::WS281X_ERROR_MEM_LOCK => "Memory lock (WS2811_ERROR_MEM_LOCK)",
+            WS281xResult::WS281X_ERROR_MMAP => "Memory map error (WS2811_ERROR_MMAP)",
+            WS281xResult::WS281X_ERROR_MAP_REGISTERS => "Register map error (WS2811_ERROR_MAP_REGISTERS)",
+            WS281xResult::WS281X_ERROR_GPIO_INIT => "Failed to initialize GPIO (WS2811_ERROR_GPIO_INIT)",
+            WS281xResult::WS281X_ERROR_PWM_SETUP => "Failed to set up PWM (WS2811_ERROR_PWM_SETUP)",
+            WS281xResult::WS281X_ERROR_MAILBOX_DEVICE => "Mailbox device error (WS2811_ERROR_MAILBOX_DEVICE)",
+            WS281xResult::WS281X_ERROR_DMA => "DMA error (WS2811_ERROR_DMA)",
+            WS281xResult::WS281X_ERROR_ILLEGAL_GPIO => "Illegal GPIO (WS2811_ERROR_ILLEGAL_GPIO)",
+            WS281xResult::WS281X_ERROR_PCM_SETUP => "Failed to set up PCM (WS2811_ERROR_PCM_SETUP)",
+            WS281xResult::WS281X_ERROR_SPI_SETUP => "Failed to set up SPI (WS2811_ERROR_SPI_SETUP)",
+            WS281xResult::WS281X_ERROR_SPI_TRANSFER => "SPI transfer failed (WS2811_ERROR_SPI_TRANSFER)",
+            // not an error. this should never get reported.
+            WS281xResult::WS2811_SUCCESS => "",
+        }
+    }
+}
+
+impl fmt::Display for WS281xResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let output = self.description();
+        write!(f, "{}", output)
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,53 @@
+pub mod errors;
+pub mod strip;
+
+use errors::WS281xResult;
+use bindings;
+use bindings::{ws2811_t, ws2811_return_t};
+
+fn return_result(ret: ws2811_return_t) -> Result<(), WS281xResult> {
+    if ret == ws2811_return_t::WS2811_SUCCESS {
+        Ok(())
+    } else {
+        Err(ret.into())
+    }
+}
+
+/// A low-level function that initializes the ws281x strand.
+///
+/// This requires that a ws2811_t struct be instantiated with
+/// some default data before calling this function. See both the
+/// ControllerBuilder and ChannelBuilder structs for the required
+/// information needed.
+pub fn ws2811_init(c_struct: *mut ws2811_t) -> Result<(), WS281xResult> {
+    unsafe {
+        return_result(bindings::ws2811_init(c_struct))
+    }
+}
+
+/// A low-level function that frees memory associated with the ws281x strand.
+pub fn ws2811_fini(c_struct: *mut ws2811_t) {
+    unsafe {
+        bindings::ws2811_fini(c_struct);
+    }
+}
+
+/// A low-level function that sends the local pixel data to the strand
+///
+/// The strand *must* be initialized first before calling!
+pub fn ws2811_render(c_struct: *mut ws2811_t) -> Result<(), WS281xResult> {
+    unsafe {
+        return_result(bindings::ws2811_render(c_struct))
+    }
+}
+
+/// A low-level function that waits for any executing DMA operation to
+/// complete before returning.
+///
+/// It shouldn't be necessary to call this function normally as both ws2811_fini
+/// and ws2811_render call this function already.
+pub fn ws2811_wait(c_struct: *mut ws2811_t) -> Result<(), WS281xResult> {
+    unsafe {
+        return_result(bindings::ws2811_wait(c_struct))
+    }
+}

--- a/src/util/strip.rs
+++ b/src/util/strip.rs
@@ -1,0 +1,106 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+use bindings::{
+    SK6812_STRIP_RGBW,
+    SK6812_STRIP_RBGW,
+    SK6812_STRIP_GRBW,
+    SK6812_STRIP_GBRW,
+    SK6812_STRIP_BRGW,
+    SK6812_STRIP_BGRW,
+    SK6812_SHIFT_WMASK,
+    WS2811_STRIP_RGB,
+    WS2811_STRIP_RBG,
+    WS2811_STRIP_GRB,
+    WS2811_STRIP_GBR,
+    WS2811_STRIP_BRG,
+    WS2811_STRIP_BGR,
+    WS2812_STRIP,
+    SK6812_STRIP,
+    SK6812W_STRIP,
+};
+
+pub const SK6812_STRIP_RGBW_I32: i32 = SK6812_STRIP_RGBW as i32;
+pub const SK6812_STRIP_RBGW_I32: i32 = SK6812_STRIP_RBGW as i32;
+pub const SK6812_STRIP_GRBW_I32: i32 = SK6812_STRIP_GRBW as i32;
+pub const SK6812_STRIP_GBRW_I32: i32 = SK6812_STRIP_GBRW as i32;
+pub const SK6812_STRIP_BRGW_I32: i32 = SK6812_STRIP_BRGW as i32;
+pub const SK6812_STRIP_BGRW_I32: i32 = SK6812_STRIP_BGRW as i32;
+pub const SK6812_SHIFT_WMASK_I32: i32 = SK6812_SHIFT_WMASK as i32;
+pub const WS2811_STRIP_RGB_I32: i32 = WS2811_STRIP_RGB as i32;
+pub const WS2811_STRIP_RBG_I32: i32 = WS2811_STRIP_RBG as i32;
+pub const WS2811_STRIP_GRB_I32: i32 = WS2811_STRIP_GRB as i32;
+pub const WS2811_STRIP_GBR_I32: i32 = WS2811_STRIP_GBR as i32;
+pub const WS2811_STRIP_BRG_I32: i32 = WS2811_STRIP_BRG as i32;
+pub const WS2811_STRIP_BGR_I32: i32 = WS2811_STRIP_BGR as i32;
+pub const WS2812_STRIP_I32: i32 = WS2812_STRIP as i32;
+pub const SK6812_STRIP_I32: i32 = SK6812_STRIP as i32;
+pub const SK6812W_STRIP_I32: i32 = SK6812W_STRIP as i32;
+
+#[derive(Debug, Copy, Clone)]
+pub enum Strip {
+    SK6812_STRIP_RGBW,
+    SK6812_STRIP_RBGW,
+    SK6812_STRIP_GRBW,
+    SK6812_STRIP_GBRW,
+    SK6812_STRIP_BRGW,
+    SK6812_STRIP_BGRW,
+    SK6812_SHIFT_WMASK,
+    WS2811_STRIP_RGB,
+    WS2811_STRIP_RBG,
+    WS2811_STRIP_GRB,
+    WS2811_STRIP_GBR,
+    WS2811_STRIP_BRG,
+    WS2811_STRIP_BGR,
+    WS2812_STRIP,
+    SK6812_STRIP,
+    SK6812W_STRIP,
+}
+
+impl From<i32> for Strip {
+    fn from(value: i32) -> Strip {
+        match value {
+            a if a == SK6812_STRIP_RGBW_I32 => Strip::SK6812_STRIP_RGBW,
+            a if a == SK6812_STRIP_RBGW_I32 => Strip::SK6812_STRIP_RBGW,
+            a if a == SK6812_STRIP_GRBW_I32 => Strip::SK6812_STRIP_GRBW,
+            a if a == SK6812_STRIP_GBRW_I32 => Strip::SK6812_STRIP_GBRW,
+            a if a == SK6812_STRIP_BRGW_I32 => Strip::SK6812_STRIP_BRGW,
+            a if a == SK6812_STRIP_BGRW_I32 => Strip::SK6812_STRIP_BGRW,
+            a if a == SK6812_SHIFT_WMASK_I32 => Strip::SK6812_SHIFT_WMASK,
+            a if a == WS2811_STRIP_RGB_I32 => Strip::WS2811_STRIP_RGB,
+            a if a == WS2811_STRIP_RBG_I32 => Strip::WS2811_STRIP_RBG,
+            a if a == WS2811_STRIP_GRB_I32 => Strip::WS2811_STRIP_GRB,
+            a if a == WS2811_STRIP_GBR_I32 => Strip::WS2811_STRIP_GBR,
+            a if a == WS2811_STRIP_BRG_I32 => Strip::WS2811_STRIP_BRG,
+            a if a == WS2811_STRIP_BGR_I32 => Strip::WS2811_STRIP_BGR,
+            a if a == WS2812_STRIP_I32 => Strip::WS2812_STRIP,
+            a if a == SK6812_STRIP_I32 => Strip::SK6812_STRIP,
+            a if a == SK6812W_STRIP_I32 => Strip::SK6812W_STRIP,
+            _ => Strip::WS2811_STRIP_RGB
+        }
+    }
+}
+
+impl Into<i32> for Strip {
+    fn into(self) -> i32 {
+        match self {
+            Strip::SK6812_STRIP_RGBW => SK6812_STRIP_RGBW_I32,
+            Strip::SK6812_STRIP_RBGW => SK6812_STRIP_RBGW_I32,
+            Strip::SK6812_STRIP_GRBW => SK6812_STRIP_GRBW_I32,
+            Strip::SK6812_STRIP_GBRW => SK6812_STRIP_GBRW_I32,
+            Strip::SK6812_STRIP_BRGW => SK6812_STRIP_BRGW_I32,
+            Strip::SK6812_STRIP_BGRW => SK6812_STRIP_BGRW_I32,
+            Strip::SK6812_SHIFT_WMASK => SK6812_SHIFT_WMASK_I32,
+            Strip::WS2811_STRIP_RGB => WS2811_STRIP_RGB_I32,
+            Strip::WS2811_STRIP_RBG => WS2811_STRIP_RBG_I32,
+            Strip::WS2811_STRIP_GRB => WS2811_STRIP_GRB_I32,
+            Strip::WS2811_STRIP_GBR => WS2811_STRIP_GBR_I32,
+            Strip::WS2811_STRIP_BRG => WS2811_STRIP_BRG_I32,
+            Strip::WS2811_STRIP_BGR => WS2811_STRIP_BGR_I32,
+            Strip::WS2812_STRIP => WS2812_STRIP_I32,
+            Strip::SK6812_STRIP => SK6812_STRIP_I32,
+            Strip::SK6812W_STRIP => SK6812W_STRIP_I32,
+        }
+    }
+}


### PR DESCRIPTION
I've merged some missing files from the original repo and completed the existing API. I have cross-compiled this library on Windows using the updates to the `build.rs` build script for the Raspberry Pi Zero W and have verified that these changes work (see GIF below) using the instructions that have been added to the README.

I am also currently writing a display/grid library that uses this API in order to control the WS2811 LEDs that I have installed in a shadow box (for my 4 month old). It further abstracts the Controller interface into a single Display which also provides a builder for completely configuring the entire application. Would this also make sense as a part of this library? Or would that be better off in a separate crate? The idea is that anything that implements the Animation trait can be displayed on the grid.

Here's an example on my 7x7 lightbox (thanks to @qtip for the animation shown).

![25501447-0065-4753-8ccd-47fc630b4611](https://user-images.githubusercontent.com/1094000/44074346-d4665cd6-9f5d-11e8-98c9-777a86bd46bc.gif)
