### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.3"
 authors = ["Joseph Murphy <air.jmurph@gmail.com>"]
 license = "MIT"
 description = "Wrapper for ws281x library using bindgen to track upstream"
+repository = "https://github.com/rpi-ws281x/rpi-ws281x-rust"
 
 [dependencies]
 serde = "1.0"


### PR DESCRIPTION
Next time this crate is published, crates.io and docs.rs will be able
to link to this repository.