### PR TITLE
Bump bindgen to 0.54; disable optional dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ serde = "1.0"
 serde_derive = "1.0"
 
 [build-dependencies]
-bindgen = "0.45"
+bindgen = { version = "0.54", default-features = false }
 cc = "1.0"
 
 [profile.release]


### PR DESCRIPTION
Bindgen enables `clap` by default (so you can `cargo install` the CLI tool without additional arguments) but most `build.rs` files don't need it. This eliminates a number of dependencies from projects that aren't using `clap`.