### PR TITLE
Make `Error` type accessible from outside crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,6 @@ mod channel;
 mod controller;
 mod util;
 
-pub use channel::ChannelBuilder;
+pub use channel::{ChannelBuilder};
 pub use controller::{Controller, ControllerBuilder};
-pub use util::{RawColor, Result, StripType, WS2811Error};
+pub use util::{StripType, RawColor};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,6 @@ mod channel;
 mod controller;
 mod util;
 
-pub use channel::{ChannelBuilder};
+pub use channel::ChannelBuilder;
 pub use controller::{Controller, ControllerBuilder};
-pub use util::{StripType, RawColor};
+pub use util::{RawColor, Result, StripType, WS2811Error};


### PR DESCRIPTION
I am using this in a library, and would like to be able to refer to the error type. So this was necessary to get my library working with `thiserror`