### PR TITLE
bump bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ serde = "1.0"
 serde_derive = "1.0"
 
 [build-dependencies]
-bindgen = { version = "0.54", default-features = false }
+bindgen = { version = "0.58", default-features = false }
 cc = "1.0"
 
 [profile.release]


### PR DESCRIPTION
Older bindgen uses an older clang-sys, which collides with another bindgen project for me. I'm using this package with this bumped version, which uses clang-sys 1.0.0