### PR TITLE
added working SPI example / use latest bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ serde = "1.0"
 serde_derive = "1.0"
 
 [build-dependencies]
-bindgen = { version = "0.54", default-features = false }
+bindgen = { version = "0.59", default-features = false }
 cc = "1.0"
 
 [profile.release]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,29 @@
+use rs_ws281x::ControllerBuilder;
+
+fn main() {
+    // Construct a single channel controller. Note that the
+    // Controller is initialized by default and is cleaned up on drop
+
+    let mut controller = ControllerBuilder::new()
+        .freq(800_000)
+        .dma(10)
+        .channel(
+            0, // Channel Index
+            ChannelBuilder::new()
+                .pin(10) // GPIO 10 = SPI0 MOSI
+                .count(64) // Number of LEDs
+                .strip_type(StripType::Ws2812)
+                .brightness(20) // default: 255
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    let leds = controller.leds_mut(0);
+
+    for led in leds {
+        *led = [0, 0, 255, 0];
+    }
+
+    controller.render().unwrap();
+}


### PR DESCRIPTION
Hey ! 
This is my first pull request ever, so forgive me if i am doing something wrong here. 

I just thought it would be a good idea to have a working example. You already had one somewhere in your source code, but the API use was outdated and did not compile. All I did was a few minor changes to make it run and light up some LEDs.

I have also increased the bindgen version, since 0.54 was relying on a really outdated clang-sys which created problems when using this library with other C-wrapped libs.

Thx :)
Andreas
