### PR TITLE
Updates submodule dep as well as Cargo deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_ws281x"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Joseph Murphy <air.jmurph@gmail.com>"]
 license = "MIT"
 description = "Wrapper for ws281x library using bindgen to track upstream"
@@ -11,7 +11,7 @@ serde = "1.0"
 serde_derive = "1.0"
 
 [build-dependencies]
-bindgen = { version = "0.59", default-features = false }
+bindgen = { version = "0.60", default-features = false }
 cc = "1.0"
 
 [profile.release]


### PR DESCRIPTION
This updates the underlying rpi_ws281x library as well as bringing the project's Cargo dependencies up to date as well for the first time in a little while.