### PR TITLE
Adds a fix for the example.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [build]
 target = "arm-unknown-linux-gnueabihf"
+
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "rs_ws281x"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Joseph Murphy <air.jmurph@gmail.com>"]
 license = "MIT"
 description = "Wrapper for ws281x library using bindgen to track upstream"
 repository = "https://github.com/rpi-ws281x/rpi-ws281x-rust"
+edition = "2018"
 
 [dependencies]
 serde = "1.0"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,6 @@
 use rs_ws281x::ControllerBuilder;
+use rs_ws281x::ChannelBuilder;
+use rs_ws281x::StripType;
 
 fn main() {
     // Construct a single channel controller. Note that the


### PR DESCRIPTION
* Also fixes the .cargo/config to use the gcc linker for ARM builds which is usually required.
* Also bumps the version for crates.io.